### PR TITLE
Fix incorrect documentation of apache2 module

### DIFF
--- a/documentation/resource_apache2_module.md
+++ b/documentation/resource_apache2_module.md
@@ -23,7 +23,7 @@ Enable the php5 module, which has a different filename than the module default:
 
 ```ruby
 apache2_module "php5" do
-  filename "libphp5.so"
+  mod_name "libphp5.so"
 end
 ```
 


### PR DESCRIPTION
# Description

Updates documentation to reflect code as filename is no longer an existing method

## Issues Resolved

Documentation causes compiler to throw error "NoMethodError: undefined method `filename' for Custom resource apache2_module from cookbook apache2"

## Check List

- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
